### PR TITLE
SITL: Add more command line arguments for port selection.

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -60,7 +60,10 @@ void SITL_State::_usage(void)
            "\t--gazebo-address ADDR    set address string for gazebo\n"
            "\t--gazebo-port-in PORT    set port num for gazebo in\n"
            "\t--gazebo-port-out PORT   set port num for gazebo out\n"
-           "\t--defaults path    set path to defaults file\n"
+           "\t--irlock-port PORT       set port num for irlock\n"
+           "\t--rc-in-port PORT        set port num for rc in\n"
+           "\t--base-port PORT         set port num for base port(default 5670) must be before -I option\n"
+           "\t--defaults path          set path to defaults file\n"
         );
 }
 
@@ -158,6 +161,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         CMDLINE_GAZEBO_ADDRESS,
         CMDLINE_GAZEBO_PORT_IN,
         CMDLINE_GAZEBO_PORT_OUT,
+        CMDLINE_BASE_PORT,
+        CMDLINE_IRLOCK_PORT,
+        CMDLINE_RCIN_PORT,
         CMDLINE_DEFAULTS
     };
 
@@ -187,6 +193,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"gazebo-address",  true,  0, CMDLINE_GAZEBO_ADDRESS},
         {"gazebo-port-in",  true,  0, CMDLINE_GAZEBO_PORT_IN},
         {"gazebo-port-out", true,  0, CMDLINE_GAZEBO_PORT_OUT},
+        {"base-port",       true,  0, CMDLINE_BASE_PORT},
+        {"irlock-port",     true,  0, CMDLINE_IRLOCK_PORT},
+        {"rc-in-port",       true,  0, CMDLINE_RCIN_PORT},
         {0, false, 0, 0}
     };
 
@@ -272,6 +281,15 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             break;
         case CMDLINE_GAZEBO_PORT_OUT:
             _gazebo_port_out = atoi(gopt.optarg);
+            break;
+        case CMDLINE_IRLOCK_PORT:
+            _irlock_port = atoi(gopt.optarg);
+            break;
+        case CMDLINE_RCIN_PORT:
+            _rcin_port = atoi(gopt.optarg);
+            break;
+        case CMDLINE_BASE_PORT:
+            _base_port = atoi(gopt.optarg);
             break;
         default:
             _usage();


### PR DESCRIPTION
There's just a few more parameterizations that make this much more flexible.

These additional options add support for arbitrary port assignments. I was running a lot of vehicles and wanted to control the ports in a more fine grained way than the 'Increment' method supported. This is why I needed ir_lock and rc_in to be able to be set. 

And I also wanted to define a different base_port to support fully controlling the ports for external control.